### PR TITLE
Feature:  add signals enigne and GET /signals endpoint

### DIFF
--- a/services/backend/api/__init__.py
+++ b/services/backend/api/__init__.py
@@ -1,0 +1,1 @@
+# api package

--- a/services/backend/api/signals.py
+++ b/services/backend/api/signals.py
@@ -1,0 +1,106 @@
+# signals.py
+# Intern 2 — Signals API Route
+# Exposes GET /signals?top=20
+# Calls signals_engine.py for all the math/logic.
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import Session, select
+from typing import List
+from datetime import datetime
+
+from services.backend.data.database import engine
+from services.backend.data.models import Market, AISignal
+from services.backend.core.signals_engine import rank_markets
+
+router = APIRouter(prefix="/signals", tags=["Signals"])
+
+
+# ─────────────────────────────────────────────
+# HELPER: convert Market DB rows → plain dicts
+# signals_engine.py works with plain dicts,
+# not SQLModel objects — this bridges the gap.
+# ─────────────────────────────────────────────
+
+def market_to_dict(market: Market) -> dict:
+    return {
+        "id":           market.id,
+        "question":     market.question,
+        "category":     market.category,
+        "current_odds": market.current_odds,
+        "is_active":    market.is_active,
+        "expires_at":   market.expires_at,
+        # These two fields power the scoring.
+        # previous_odds: ideally from last snapshot — defaulting to current for now.
+        # avg_volume:    ideally a rolling average — defaulting to a baseline.
+        # Intern 1 can enrich these fields later when more data is available.
+        "previous_odds": getattr(market, "previous_odds", market.current_odds),
+        "volume":        getattr(market, "volume", 1000),
+        "avg_volume":    getattr(market, "avg_volume", 500),
+    }
+
+
+# ─────────────────────────────────────────────
+# GET /signals?top=20
+# Returns top N ranked markets with scores and reasons.
+# Used by: Telegram /signals command, Dashboard Signals page, OpenClaw agent
+# ─────────────────────────────────────────────
+
+@router.get("/")
+def get_signals(top: int = 20):
+    """
+    Returns the top ranked prediction markets based on:
+    - Momentum (price movement)
+    - Volume spike (unusual activity)
+    - Liquidity filter (removes thin markets)
+
+    Each result includes a plain-English 'reason' field.
+    """
+    with Session(engine) as session:
+        # Fetch only active markets from the database
+        statement = select(Market).where(Market.is_active == True)
+        markets = session.exec(statement).all()
+
+        if not markets:
+            return {
+                "signals": [],
+                "count": 0,
+                "message": "No active markets found. Intern 1 needs to populate the markets table."
+            }
+
+        # Convert to dicts and run through the signals engine
+        market_dicts = [market_to_dict(m) for m in markets]
+        ranked = rank_markets(market_dicts, top=top)
+
+        # Save snapshot to DB so Dashboard and OpenClaw have history
+        save_signal_snapshot(session, ranked)
+
+        return {
+            "signals": ranked,
+            "count": len(ranked),
+            "generated_at": datetime.utcnow().isoformat()
+        }
+
+
+# ─────────────────────────────────────────────
+# HELPER: Save signals snapshot to AISignal table
+# This gives the Dashboard historical data
+# and gives the volume scorer a baseline over time.
+# ─────────────────────────────────────────────
+
+def save_signal_snapshot(session: Session, ranked: list):
+    """
+    Saves the current top signals into the AISignal table.
+    Intern 6 (Dashboard) reads from this table for the Signals page.
+    Intern 3 (OpenClaw) calls get_signals() which hits this endpoint.
+    """
+    for signal in ranked:
+        snapshot = AISignal(
+            market_id=signal["market_id"],
+            prediction="N/A",               # OpenClaw fills this — we just store the score
+            confidence_score=signal["score"],
+            analysis_summary=signal["reason"],
+            timestamp=datetime.utcnow()
+        )
+        session.add(snapshot)
+
+    session.commit()

--- a/services/backend/core/__init__.py
+++ b/services/backend/core/__init__.py
@@ -1,0 +1,1 @@
+# core package

--- a/services/backend/core/signals_engine.py
+++ b/services/backend/core/signals_engine.py
@@ -1,0 +1,181 @@
+# signals_engine.py
+# Intern 2 — Signals Engine
+# This file contains all the scoring logic.
+# It is imported by api/signals.py to power the GET /signals endpoint.
+
+from datetime import datetime
+from typing import List, Dict
+
+# ─────────────────────────────────────────────
+# CONFIGURATION
+# Tune these thresholds as you test
+# ─────────────────────────────────────────────
+
+MIN_LIQUIDITY = 1000.0      # Markets below this are too thin to trade
+MOMENTUM_WEIGHT = 0.5       # How much price movement matters in final score
+VOLUME_WEIGHT = 0.5         # How much volume spike matters in final score
+
+
+# ─────────────────────────────────────────────
+# STEP 1 — LIQUIDITY FILTER
+# Gates every market before scoring.
+# If a market fails this, it never gets ranked.
+# ─────────────────────────────────────────────
+
+def passes_liquidity_filter(market: Dict) -> bool:
+    """
+    Returns True if the market has enough liquidity to be worth ranking.
+    Uses the 'volume' field as a proxy for liquidity.
+    """
+    volume = market.get("volume", 0)
+    return volume >= MIN_LIQUIDITY
+
+
+# ─────────────────────────────────────────────
+# STEP 2 — MOMENTUM SCORE
+# Measures how much the price has moved recently.
+# Uses current_odds vs previous_odds stored in the market snapshot.
+# Score is between 0.0 and 1.0
+# ─────────────────────────────────────────────
+
+def momentum_score(market: Dict) -> float:
+    """
+    Calculates a normalized momentum score based on price change.
+    current_odds  = latest price (e.g. 0.72)
+    previous_odds = price from last snapshot (e.g. 0.50)
+    """
+    current = market.get("current_odds", 0.5)
+    previous = market.get("previous_odds", current)  # fallback: no change
+
+    if previous == 0:
+        return 0.0
+
+    raw_change = abs(current - previous) / previous  # e.g. 0.44 = 44% move
+
+    # Cap at 1.0 — a 100%+ move still scores 1.0
+    return min(raw_change, 1.0)
+
+
+# ─────────────────────────────────────────────
+# STEP 3 — VOLUME SPIKE SCORE
+# Measures how unusual the current volume is
+# compared to a simple baseline.
+# Score is between 0.0 and 1.0
+# ─────────────────────────────────────────────
+
+def volume_spike_score(market: Dict) -> float:
+    """
+    Compares current volume to a baseline average volume.
+    A market with 3x its average volume scores higher.
+    avg_volume is stored on the market dict — Intern 1 should provide this,
+    or we fall back to a default baseline.
+    """
+    current_volume = market.get("volume", 0)
+    avg_volume = market.get("avg_volume", 500)  # fallback baseline
+
+    if avg_volume == 0:
+        return 0.0
+
+    ratio = current_volume / avg_volume  # e.g. 3.2 means 3.2x average
+
+    # Normalize: cap at 5x = score of 1.0
+    # So 1x = 0.2, 3x = 0.6, 5x+ = 1.0
+    return min(ratio / 5.0, 1.0)
+
+
+# ─────────────────────────────────────────────
+# STEP 4 — COMPOSITE SCORE
+# Combines momentum + volume into one final number.
+# ─────────────────────────────────────────────
+
+def composite_score(market: Dict) -> float:
+    """
+    Final ranking score for a market.
+    Weighted combination of momentum and volume spike.
+    Returns a value between 0.0 and 1.0
+    """
+    m = momentum_score(market)
+    v = volume_spike_score(market)
+    return round((MOMENTUM_WEIGHT * m) + (VOLUME_WEIGHT * v), 4)
+
+
+# ─────────────────────────────────────────────
+# STEP 5 — REASON STRING
+# Every ranked market must explain WHY it ranked.
+# This shows up in Telegram and on the Dashboard.
+# ─────────────────────────────────────────────
+
+def build_reason(market: Dict) -> str:
+    """
+    Generates a plain-English explanation for why this market ranked.
+    Example output: "Price moved +18% with 3.2x average volume."
+    """
+    current = market.get("current_odds", 0.5)
+    previous = market.get("previous_odds", current)
+    volume = market.get("volume", 0)
+    avg_volume = market.get("avg_volume", 500)
+
+    # Price change as a percentage
+    if previous > 0:
+        price_change_pct = ((current - previous) / previous) * 100
+        price_str = f"Price moved {price_change_pct:+.1f}%"
+    else:
+        price_str = "Price data unavailable"
+
+    # Volume ratio
+    if avg_volume > 0:
+        ratio = volume / avg_volume
+        volume_str = f"{ratio:.1f}x average volume"
+    else:
+        volume_str = "volume data unavailable"
+
+    return f"{price_str} with {volume_str}."
+
+
+# ─────────────────────────────────────────────
+# STEP 6 — MAIN RANKING FUNCTION
+# This is what signals.py calls.
+# Takes a list of raw market dicts, returns ranked signals.
+# ─────────────────────────────────────────────
+
+def rank_markets(markets: List[Dict], top: int = 20) -> List[Dict]:
+    """
+    Main entry point for the signals engine.
+
+    1. Filters out illiquid markets
+    2. Scores each remaining market
+    3. Sorts by composite score (highest first)
+    4. Returns top N with reason strings attached
+
+    Each returned dict includes:
+      - market_id
+      - question
+      - score
+      - reason
+      - current_odds
+      - volume
+    """
+    # Step 1: filter
+    liquid_markets = [m for m in markets if passes_liquidity_filter(m)]
+
+    # Step 2 & 3: score and sort
+    scored = sorted(liquid_markets, key=composite_score, reverse=True)
+
+    # Step 4: build output
+    results = []
+    for market in scored[:top]:
+        score = composite_score(market)
+        reason = build_reason(market)
+
+        results.append({
+            "market_id":    market.get("id"),
+            "question":     market.get("question", "Unknown market"),
+            "score":        score,
+            "reason":       reason,
+            "current_odds": market.get("current_odds"),
+            "volume":       market.get("volume"),
+            "category":     market.get("category", "general"),
+            "expires_at":   str(market.get("expires_at", "")),
+        })
+
+    return results

--- a/services/backend/main.py
+++ b/services/backend/main.py
@@ -1,0 +1,2 @@
+from services.backend.api.signals import router as signals_router
+app.include_router(signals_router)


### PR DESCRIPTION
### What I built
- `services/backend/core/signals_engine.py` — all scoring logic
- `services/backend/api/signals.py` — GET /signals?top=20 endpoint

### How it works
Markets are scored across 3 factors:
- Momentum: measures price change between current and previous odds
- Volume Spike: compares current volume to average volume
- Liquidity Filter: drops markets below $1,000 volume (not worth trading)

Each result includes a plain-English `reason` field explaining why it ranked.

### What it returns
```json
{
  "signals": [
    {
      "market_id": "market-001",
      "question": "Will BTC hit $100k by March?",
      "score": 0.72,
      "reason": "Price moved +44.0% with 16.0x average volume.",
      "current_odds": 0.72,
      "volume": 8000
    }
  ],
  "count": 1,
  "generated_at": "2026-02-19T10:00:00"
}
