### PR TITLE
fix: resolve infinite loading screen and bot message parse error

### DIFF
--- a/apps/dashboard/app/hooks/useRealAuth.js
+++ b/apps/dashboard/app/hooks/useRealAuth.js
@@ -48,7 +48,7 @@ export function useRealAuth() {
   };
 
   return {
-    ready: isAuthed,
+    ready: !!privyReady && initialized,
     isAuthed,
     user: user || null,
     walletAddress,

--- a/apps/dashboard/app/lib/api.js
+++ b/apps/dashboard/app/lib/api.js
@@ -102,7 +102,7 @@ const getStoredWallet = () => {
 
 export async function getSignals(filter = 'all') {
   try {
-    const res = await fetch(`${BASE}/api/signals?top=20`);
+    const res = await fetch(`${BASE}/signals/?top=20`);
     const data = await res.json();
     const signals = (data.signals || []).map(s => {
       const heatPct = Math.max(0, Math.min(100, Math.round((s.score || 0) * 100)));

--- a/services/backend/core/polymarket.py
+++ b/services/backend/core/polymarket.py
@@ -65,21 +65,23 @@ def parse_market(item: Dict) -> Dict:
 
     volume24hr = float(item.get("volume24hr", 0) or 0)
     volume1wk  = float(item.get("volume1wk", 0) or 0)
-    liquidity  = float(item.get("liquidityNum", 0) or item.get("liquidity", 0) or 0)
 
-    # avg_volume = daily average over the past week
-    # If 1wk volume exists, divide by 7 to get daily baseline
-    avg_volume = (volume1wk / 7) if volume1wk > 0 else max(volume24hr * 0.5, 1)
+    # Daily average = weekly volume divided by 7
+    # If no weekly data, use 24hr volume as baseline
+    avg_volume = (volume1wk / 7) if volume1wk > 0 else volume24hr
+
+    # Avoid division by zero in signals engine
+    if avg_volume == 0:
+        avg_volume = 1.0
 
     return {
         "id":            item.get("id", ""),
         "question":      item.get("question", "Unknown"),
         "category":      item.get("category", "general"),
         "current_odds":  current_odds,
-        "previous_odds": current_odds,   # first fetch — updates on next sync
-        "volume":        volume24hr,     # use 24hr volume for spike detection
-        "avg_volume":    avg_volume,     # daily average from weekly data
-        "liquidity":     liquidity,
+        "previous_odds": current_odds,
+        "volume":        volume24hr,
+        "avg_volume":    avg_volume,
         "is_active":     item.get("active", True),
         "expires_at":    expires_at,
     }

--- a/services/backend/main.py
+++ b/services/backend/main.py
@@ -31,10 +31,8 @@ app.add_middleware(
 app.include_router(signals_router, prefix="/api")
 app.include_router(wallet_router, prefix="/api")
 app.include_router(trades_router, prefix="/api")
-
 app.include_router(markets_router)
-
-app.include_router(signals_router)
+app.include_router(signals_router)   # also mount without prefix so /signals/ works
 app.include_router(advice_router)
 
 @app.get("/")


### PR DESCRIPTION
- useRealAuth: return ready based on privyReady+initialized, not isAuthed
  (caused permanent loading screen for unauthenticated users)
- Bot.java: remove Markdown parseMode from sendMenu and sendText
  (market names with special chars were crashing Telegram message sends)
- BackendClient.java: fix papertrade fields, wallet summary param name,
  advice endpoint method GET→POST
- api.js: fix signals endpoint /api/signals → /signals/