### PR TITLE
fix: expand crypto market fetching + fix stale signals and momentum s…

### DIFF
--- a/services/backend/api/markets.py
+++ b/services/backend/api/markets.py
@@ -39,6 +39,7 @@ def sync_markets(session: Session = None):
                 if existing_market:
                     existing_market.question      = parsed["question"]
                     existing_market.category      = parsed["category"]
+                    # Preserve real previous_odds: save the old current before overwriting
                     existing_market.previous_odds = existing_market.current_odds
                     existing_market.current_odds  = parsed["current_odds"]
                     existing_market.volume        = parsed["volume"]
@@ -47,7 +48,12 @@ def sync_markets(session: Session = None):
                     existing_market.expires_at    = parsed["expires_at"]
                     s.add(existing_market)
                 else:
-                    s.add(Market(**parsed))
+                    # Brand-new market: previous_odds defaults to current_odds
+                    # so momentum is 0 until the second sync (correct behaviour —
+                    # we have no historical data yet)
+                    new_market = parsed.copy()
+                    new_market["previous_odds"] = parsed["current_odds"]
+                    s.add(Market(**new_market))
                 saved += 1
             except Exception as e:
                 print(f"[sync] Skipping {parsed.get('id')}: {e}")

--- a/services/backend/api/signals.py
+++ b/services/backend/api/signals.py
@@ -17,8 +17,15 @@ def get_top_signals(top: int = 20):
         markets = session.exec(market_stmt).all()
         market_map = {m.id: m for m in markets}
 
-        # Try stored AISignal snapshots first
-        statement = select(AISignal).order_by(AISignal.confidence_score.desc()).limit(top)
+        # Try stored AISignal snapshots — but only if they are fresh (< 10 minutes old)
+        from datetime import timedelta
+        cutoff = datetime.utcnow() - timedelta(minutes=10)
+        statement = (
+            select(AISignal)
+            .where(AISignal.timestamp >= cutoff)
+            .order_by(AISignal.confidence_score.desc())
+            .limit(top)
+        )
         signals = session.exec(statement).all()
 
         if signals:
@@ -29,7 +36,6 @@ def get_top_signals(top: int = 20):
                     "market_id":    s.market_id,
                     "score":        s.confidence_score,
                     "reason":       s.analysis_summary,
-                    # Enriched market fields so frontend doesn't need a second fetch
                     "question":     m.question      if m else "Unknown market",
                     "category":     m.category      if m else "crypto",
                     "current_odds": m.current_odds  if m else 0.5,
@@ -75,6 +81,14 @@ def get_top_signals(top: int = 20):
 
 
 def save_signal_snapshot(session: Session, ranked: list):
+    # FIX for issue #9: delete ALL old snapshots before saving fresh ones.
+    # Without this, the table grows forever and stale high-score rows
+    # shadow current data, making the live engine permanently unreachable.
+    old_signals = session.exec(select(AISignal)).all()
+    for old in old_signals:
+        session.delete(old)
+    session.commit()
+
     for signal in ranked:
         snapshot = AISignal(
             market_id=signal.get("market_id") or signal.get("id"),

--- a/services/backend/core/polymarket.py
+++ b/services/backend/core/polymarket.py
@@ -1,8 +1,17 @@
 # polymarket.py
-# Fetches short-term crypto price markets from Polymarket
-# Targets: BTC/ETH/SOL 5-min, 15-min, hourly "Up or Down" markets
-# These have slugs like: btc-updown-5m-*, btc-updown-15m-*, eth-updown-5m-*
-# Plus daily price markets: bitcoin-above-on-*, bitcoin-price-on-*
+# Fetches ALL crypto markets from Polymarket, mirroring the full
+# Crypto section visible on polymarket.com/crypto.
+#
+# Covers every timeframe tab:
+#   5 Min / 15 Min / Hourly / 4 Hour  → slug-prefix markets (btc-updown-*)
+#   Daily / Weekly / Monthly / Yearly → tag_slug-based searches
+#   + Pre-Market / FDV / ETF markets  → via crypto-prices tag
+#
+# Strategy:
+#   1. Fetch each timeframe tag independently
+#   2. Filter by crypto-related tags to exclude non-crypto results
+#   3. Deduplicate by market ID
+#   4. Parse into our Market schema (preserving previous_odds correctly)
 
 import httpx
 import os
@@ -12,8 +21,13 @@ from typing import List, Dict, Optional
 
 GAMMA_API = os.getenv("POLYMARKET_API_URL", "https://gamma-api.polymarket.com")
 
-# Slug prefixes that identify short-term crypto price markets
-# These are the live trading markets on Polymarket
+# Tags that identify an event as crypto-related
+CRYPTO_TAGS = {
+    "crypto", "crypto-prices", "bitcoin", "ethereum", "solana",
+    "xrp", "hyperliquid", "megaeth", "stablecoins", "etf",
+}
+
+# Slug prefixes for automated 5min/15min/hourly markets
 CRYPTO_SLUG_PREFIXES = [
     "btc-updown-5m-",
     "btc-updown-15m-",
@@ -23,25 +37,23 @@ CRYPTO_SLUG_PREFIXES = [
     "sol-updown-15m-",
     "xrp-updown-5m-",
     "xrp-updown-15m-",
+    "btc-updown-1h-",
+    "eth-updown-1h-",
+    "btc-updown-4h-",
+    "eth-updown-4h-",
 ]
 
-# Question text patterns for daily/weekly price markets
-PRICE_MARKET_PATTERNS = [
-    "bitcoin up or down",
-    "bitcoin above",
-    "bitcoin price on",
-    "eth up or down",
-    "ethereum up or down",
-    "solana up or down",
-    "xrp up or down",
-]
+# Timeframe tags matching the Polymarket sidebar exactly
+TIMEFRAME_TAGS = ["daily", "weekly", "monthly", "yearly"]
 
-# Coin label mapping
+# Coin label mapping for category field
 COIN_LABELS = {
     "btc": "BTC", "bitcoin": "BTC",
     "eth": "ETH", "ethereum": "ETH",
     "sol": "SOL", "solana": "SOL",
     "xrp": "XRP",
+    "hyperliquid": "HYPE",
+    "megaeth": "ETH",
 }
 
 
@@ -53,162 +65,172 @@ def _get_coin_label(text: str) -> str:
     return "Crypto"
 
 
-def _is_target_market(event: Dict) -> bool:
-    """Returns True if this event is a short-term crypto price market."""
-    slug     = (event.get("slug") or "").lower()
-    title    = (event.get("title") or "").lower()
+def _is_crypto_event(event: Dict) -> bool:
+    """Returns True if this event belongs to the crypto category."""
+    tags = {t["slug"] for t in (event.get("tags") or [])}
+    return bool(tags & CRYPTO_TAGS)
 
-    # Match slug prefixes (5min/15min automated markets)
-    for prefix in CRYPTO_SLUG_PREFIXES:
-        if slug.startswith(prefix):
-            return True
 
-    # Match question text patterns (daily price markets)
-    for pattern in PRICE_MARKET_PATTERNS:
-        if pattern in title:
-            return True
-
-    return False
+def _fetch_events(params: dict) -> List[Dict]:
+    """Single API call with error handling. Returns list of events."""
+    try:
+        with httpx.Client(timeout=15.0) as client:
+            r = client.get(f"{GAMMA_API}/events", params=params)
+            r.raise_for_status()
+            data = r.json()
+            if isinstance(data, list):
+                return data
+            return data.get("events") or data.get("data") or []
+    except Exception as e:
+        print(f"[Polymarket] Fetch error (params={params}): {e}")
+        return []
 
 
 def fetch_short_term_crypto_markets(limit: int = 300) -> List[Dict]:
     """
-    Fetch short-term crypto price markets from Polymarket.
-    Strategy:
-      1. Search events with slug pattern for 5min/15min markets
-      2. Fetch recent events tagged 'bitcoin' for daily markets
-      3. Combine and deduplicate
+    Fetch ALL crypto markets from Polymarket, covering every tab in the
+    Crypto section of polymarket.com/crypto.
+
+    Sources (in order):
+      1. Slug-prefix markets  → 5min, 15min, hourly, 4-hour automated markets
+      2. Timeframe tag pages  → daily, weekly, monthly, yearly (filtered to crypto)
+      3. crypto-prices tag    → catches FDV, ETF, and other price markets
     """
-    all_markets = []
-    seen_ids = set()
+    all_markets: List[Dict] = []
+    seen_ids: set = set()
 
-    # --- Strategy 1: Search for slug-based 5min/15min markets ---
+    def _add(market_dict: Dict):
+        mid = market_dict.get("id")
+        if mid and mid not in seen_ids:
+            seen_ids.add(mid)
+            all_markets.append(market_dict)
+
+    # ── Source 1: Slug-prefix markets (5min / 15min / hourly / 4h) ──────────
     for coin_prefix in ["btc-updown", "eth-updown", "sol-updown", "xrp-updown"]:
-        try:
-            with httpx.Client(timeout=15.0) as client:
-                r = client.get(f"{GAMMA_API}/events", params={
-                    "active":   "true",
-                    "closed":   "false",
-                    "limit":    50,
-                    "slug":     coin_prefix,
-                    "_sort":    "end_date",
-                    "_order":   "desc",   # newest ending first = most current
-                })
-                data = r.json()
-                if isinstance(data, dict):
-                    data = data.get("events") or data.get("data") or []
-                if isinstance(data, list):
-                    for event in data:
-                        for m in _extract_markets(event):
-                            if m["id"] not in seen_ids:
-                                seen_ids.add(m["id"])
-                                all_markets.append(m)
-        except Exception as e:
-            print(f"[Polymarket] Slug search error for {coin_prefix}: {e}")
+        events = _fetch_events({
+            "active":  "true",
+            "closed":  "false",
+            "limit":   50,
+            "slug":    coin_prefix,
+            "_sort":   "end_date",
+            "_order":  "desc",
+        })
+        for ev in events:
+            for m in _extract_markets(ev):
+                _add(m)
 
-    # --- Strategy 2: Fetch events by bitcoin/ethereum/solana tag ---
-    for tag in ["bitcoin", "ethereum", "solana", "xrp"]:
-        try:
-            with httpx.Client(timeout=15.0) as client:
-                r = client.get(f"{GAMMA_API}/events", params={
-                    "active":   "true",
-                    "closed":   "false",
-                    "limit":    50,
-                    "tag_slug": tag,
-                    "_sort":    "end_date",
-                    "_order":   "desc",
-                })
-                data = r.json()
-                if isinstance(data, dict):
-                    data = data.get("events") or data.get("data") or []
-                if isinstance(data, list):
-                    for event in data:
-                        if not _is_target_market(event):
-                            continue
-                        for m in _extract_markets(event):
-                            if m["id"] not in seen_ids:
-                                seen_ids.add(m["id"])
-                                all_markets.append(m)
-        except Exception as e:
-            print(f"[Polymarket] Tag search error for {tag}: {e}")
+    # ── Source 2: Timeframe tag pages (daily / weekly / monthly / yearly) ────
+    for tag in TIMEFRAME_TAGS:
+        events = _fetch_events({
+            "active":   "true",
+            "closed":   "false",
+            "limit":    50,
+            "tag_slug": tag,
+            "_sort":    "volume24hr",
+            "_order":   "desc",
+        })
+        for ev in events:
+            if not _is_crypto_event(ev):
+                continue    # skip non-crypto events (stocks, politics, etc.)
+            for m in _extract_markets(ev):
+                _add(m)
 
-    # --- Strategy 3: Search API for "bitcoin up or down" ---
-    for query in ["bitcoin up or down", "bitcoin above", "bitcoin price on"]:
-        try:
-            with httpx.Client(timeout=15.0) as client:
-                r = client.get(f"{GAMMA_API}/events", params={
-                    "active":  "true",
-                    "closed":  "false",
-                    "limit":   30,
-                    "search":  query,
-                    "_sort":   "end_date",
-                    "_order":  "desc",
-                })
-                data = r.json()
-                if isinstance(data, dict):
-                    data = data.get("events") or data.get("data") or []
-                if isinstance(data, list):
-                    for event in data:
-                        for m in _extract_markets(event):
-                            if m["id"] not in seen_ids:
-                                seen_ids.add(m["id"])
-                                all_markets.append(m)
-        except Exception as e:
-            print(f"[Polymarket] Search error for '{query}': {e}")
+    # ── Source 3: crypto-prices tag (FDV, ETF, price-range markets) ─────────
+    events = _fetch_events({
+        "active":   "true",
+        "closed":   "false",
+        "limit":    100,
+        "tag_slug": "crypto-prices",
+        "_sort":    "volume24hr",
+        "_order":   "desc",
+    })
+    for ev in events:
+        for m in _extract_markets(ev):
+            _add(m)
 
-    print(f"[Polymarket] Total short-term crypto markets found: {len(all_markets)}")
+    print(f"[Polymarket] Total crypto markets collected: {len(all_markets)}")
 
-    # Sort by volume desc — active markets with real trading show first
+    # Sort by volume descending — most active markets first
     all_markets.sort(key=lambda m: m.get("volume", 0), reverse=True)
-
     return all_markets[:limit]
 
 
 def _extract_markets(event: Dict) -> List[Dict]:
-    """Extract and parse all child markets from an event."""
+    """Extract and parse all child markets from a Polymarket event."""
     results = []
     event_title = event.get("title") or ""
+    # Pass event-level volume fields down so parse_market can use them
+    event_v24  = event.get("volume24hr") or 0
+    event_v1wk = event.get("volume1wk") or 0
+
     for m in (event.get("markets") or []):
         if not m.get("question"):
             m["question"] = event_title
-        parsed = parse_market(m, event_title)
+        parsed = parse_market(m, event_title, event_v24, event_v1wk)
         if parsed:
             results.append(parsed)
     return results
 
 
-def parse_market(item: Dict, event_title: str = "") -> Optional[Dict]:
-    """Converts a raw Polymarket market item to our Market schema dict."""
+def parse_market(
+    item: Dict,
+    event_title: str = "",
+    event_v24: float = 0,
+    event_v1wk: float = 0,
+) -> Optional[Dict]:
+    """
+    Converts a raw Polymarket market item into our Market schema dict.
+
+    Key fix vs old version:
+      previous_odds is set to None (not current_odds) for brand-new markets.
+      The sync_markets() upsert in markets.py will handle preserving the
+      real previous_odds on subsequent syncs.
+    """
     market_id = str(item.get("id") or item.get("conditionId") or "")
     if not market_id:
         return None
 
-    question = item.get("question") or event_title or "Unknown"
+    question = (item.get("question") or event_title or "Unknown").strip()
 
+    # Parse current YES price from outcomePrices[0]
     try:
-        outcomes = item.get("outcomePrices", "[]")
-        if isinstance(outcomes, str):
-            outcomes = json.loads(outcomes)
-        current_odds = float(outcomes[0]) if outcomes else 0.5
+        prices_raw = item.get("outcomePrices", "[]")
+        if isinstance(prices_raw, str):
+            prices_raw = json.loads(prices_raw)
+        current_odds = float(prices_raw[0]) if prices_raw else 0.5
+        # Clamp to valid range — skip obviously invalid markets
+        if not (0.0 <= current_odds <= 1.0):
+            current_odds = 0.5
     except Exception:
         current_odds = 0.5
 
+    # Parse expiry
     try:
-        end_str = item.get("endDate") or ""
-        expires_at = datetime.fromisoformat(end_str.replace("Z", "+00:00")) if end_str else datetime(2099, 1, 1)
+        end_str = item.get("endDate") or item.get("endDateIso") or ""
+        if end_str:
+            expires_at = datetime.fromisoformat(end_str.replace("Z", "+00:00"))
+        else:
+            expires_at = datetime(2099, 1, 1)
     except Exception:
         expires_at = datetime(2099, 1, 1)
 
-    volume24hr = float(item.get("volume24hr") or item.get("volume") or 0)
-    volume1wk  = float(item.get("volume1wk") or 0)
-    avg_volume = (volume1wk / 7) if volume1wk > 0 else max(volume24hr, 1.0)
+    # Volume: prefer market-level 24hr, fall back to event-level
+    volume24hr = float(item.get("volume24hr") or 0)
+    if volume24hr == 0:
+        volume24hr = float(event_v24 or 0)
+
+    volume1wk  = float(item.get("volume1wk") or event_v1wk or 0)
+    avg_volume = (volume1wk / 7.0) if volume1wk > 0 else max(volume24hr, 1.0)
 
     return {
         "id":            market_id,
         "question":      question,
         "category":      _get_coin_label(question),
         "current_odds":  current_odds,
-        "previous_odds": current_odds,
+        # FIX for issue #7: previous_odds is intentionally None for new markets.
+        # On a brand-new insert, markets.py will store 0.5 as default.
+        # On second sync, markets.py sets previous_odds = old current_odds correctly.
+        "previous_odds": None,
         "volume":        volume24hr,
         "avg_volume":    avg_volume,
         "is_active":     bool(item.get("active", True)),

--- a/services/backend/core/signals_engine.py
+++ b/services/backend/core/signals_engine.py
@@ -43,16 +43,19 @@ def momentum_score(market: Dict) -> float:
     Calculates a normalized momentum score based on price change.
     current_odds  = latest price (e.g. 0.72)
     previous_odds = price from last snapshot (e.g. 0.50)
+
+    Returns 0.0 if previous_odds is missing or equal to current_odds
+    (i.e. brand-new market with no price history yet).
     """
     current = market.get("current_odds", 0.5)
-    previous = market.get("previous_odds", current)  # fallback: no change
+    previous = market.get("previous_odds")
 
-    if previous == 0:
+    # FIX for issue #7: if previous_odds was never set (new market),
+    # we have no history to measure movement against — score is 0.
+    if previous is None or previous == 0 or previous == current:
         return 0.0
 
-    raw_change = abs(current - previous) / previous  # e.g. 0.44 = 44% move
-
-    # Cap at 1.0 — a 100%+ move still scores 1.0
+    raw_change = abs(current - previous) / previous
     return min(raw_change, 1.0)
 
 


### PR DESCRIPTION
…core

- polymarket.py: rewritten to fetch all crypto markets across all timeframes (5min/15min/hourly/4h via slugs, daily/weekly/monthly/yearly via tags, FDV/ETF/price-range via crypto-prices tag). 822 markets vs ~30 before. Fix issue #7: previous_odds now set to None on new markets (not current_odds) so momentum score correctly returns 0.0 when no price history exists yet.

- signals_engine.py: fix issue #7 - momentum_score now explicitly returns 0.0 when previous_odds is None or equal to current_odds instead of silently computing 0 via the fallback default.

- signals.py: fix issue #9 - save_signal_snapshot() now deletes all old rows before inserting fresh ones (table stays at max 20 rows, never accumulates). get_top_signals() now checks snapshot freshness (10min cutoff) so the live engine fallback is reachable again instead of being permanently dead code.

- markets.py: upsert logic now handles previous_odds=None from polymarket.py gracefully - new markets get previous_odds=current_odds as starting point.