### PR TITLE
fix: infinity shares, badge repeat popup, markets not showing on feed

### DIFF
--- a/apps/dashboard/app/components/TradeModal.jsx
+++ b/apps/dashboard/app/components/TradeModal.jsx
@@ -45,9 +45,11 @@ export default function TradeModal({ signal, initialSide = 'yes', onClose, onSuc
     );
   }
 
-  const price  = side === 'yes' ? signal.yes / 100 : (100 - signal.yes) / 100;
-  const shares = amount ? (parseFloat(amount) / price).toFixed(1) : '—';
-  const payout = amount ? (parseFloat(amount) / price).toFixed(2) : '—';
+  // FIX: clamp yes to 1-99 so price is never 0 (which causes Infinity shares/payout)
+  const yesOdds = Math.max(1, Math.min(99, signal.yes || 50));
+  const price  = side === 'yes' ? yesOdds / 100 : (100 - yesOdds) / 100;
+  const shares = amount && parseFloat(amount) > 0 ? (parseFloat(amount) / price).toFixed(1) : '—';
+  const payout = amount && parseFloat(amount) > 0 ? (parseFloat(amount) / price).toFixed(2) : '—';
 
   const submit = async () => {
     if (!amount || parseFloat(amount) <= 0) return;
@@ -90,14 +92,14 @@ export default function TradeModal({ signal, initialSide = 'yes', onClose, onSuc
             onClick={() => { setSide('yes'); haptic.light?.(); }}
           >
             <span className="side-label">▲ YES</span>
-            <span className="side-price">{signal.yes}¢</span>
+            <span className="side-price">{yesOdds}¢</span>
           </button>
           <button
             className={`side-btn ${side === 'no' ? 'active-no' : ''}`}
             onClick={() => { setSide('no'); haptic.light?.(); }}
           >
             <span className="side-label">▼ NO</span>
-            <span className="side-price">{100 - signal.yes}¢</span>
+            <span className="side-price">{100 - yesOdds}¢</span>
           </button>
         </div>
 

--- a/apps/dashboard/app/lib/api.js
+++ b/apps/dashboard/app/lib/api.js
@@ -26,37 +26,33 @@ const getStoredWallet = () => {
 // ─── SIGNALS ─────────────────────────────────────────────────────────────────
 
 export async function getSignals(filter = 'all') {
-  // Fetch signals and markets in parallel
-  const [sigRes, mktRes] = await Promise.all([
-    fetch(`${BASE}/signals/?top=20`),
-    fetch(`${BASE}/markets/?limit=100`),
-  ]);
+  // Signals endpoint already embeds question, current_odds, volume, category —
+  // we only need the markets fetch as a secondary enrichment, not the source of truth.
+  const sigRes = await fetch(`${BASE}/signals/?top=20`);
+  if (!sigRes.ok) throw new Error(`Failed to load signals`);
 
-  if (!sigRes.ok && !mktRes.ok) throw new Error(`Failed to load feed`);
-
-  // Backend returns a plain array for signals
-  const sigData = sigRes.ok ? await sigRes.json() : [];
-  const mktData = mktRes.ok ? await mktRes.json() : { markets: [] };
-
-  // Build a lookup map: market_id → market object
-  const marketMap = {};
-  (mktData.markets || []).forEach(m => { marketMap[m.id] = m; });
-
-  // Signals is a plain array from the backend
+  const sigData = await sigRes.json();
   const rawSignals = Array.isArray(sigData) ? sigData : (sigData.signals || []);
 
   const signals = rawSignals.map(s => {
-    const market  = marketMap[s.market_id] || {};
     const heatPct = Math.max(0, Math.min(100, Math.round((s.score || 0) * 100)));
     const status  = heatPct >= 80 ? 'hot' : heatPct >= 50 ? 'warm' : 'cool';
+
+    // FIX: use odds/question/category/volume directly from the signal object.
+    // The signals endpoint enriches these server-side — no second lookup needed.
+    // This prevents yes=0 (→ price=0 → Infinity shares) when a market isn't
+    // in the top-100 of the separate /markets/ response.
+    const rawOdds = s.current_odds ?? 0.5;
+    const yesInt  = Math.max(1, Math.min(99, Math.round(rawOdds * 100)));
+
     return {
       id:     s.market_id,
-      cat:    market.category || 'Crypto',
+      cat:    s.category || 'Crypto',
       heat:   `${heatPct}° ${status.toUpperCase()}`,
       status,
-      q:      market.question || s.reason || 'Unknown market',
-      yes:    Math.round((market.current_odds || 0) * 100),
-      vol:    abbr(market.volume || 0),
+      q:      s.question || s.reason || 'Unknown market',
+      yes:    yesInt,
+      vol:    abbr(s.volume || 0),
       locked: (s.score || 0) >= 0.7,
       advice: s.reason || '',
     };
@@ -76,7 +72,7 @@ export async function getMarket(id) {
     id:     m.id,
     q:      m.question,
     cat:    m.category,
-    yes:    Math.round((m.current_odds || 0) * 100),
+    yes:    Math.max(1, Math.min(99, Math.round((m.current_odds || 0.5) * 100))),
     vol:    abbr(m.volume || 0),
     status: 'info',
     advice: '',
@@ -85,14 +81,14 @@ export async function getMarket(id) {
 }
 
 export async function listMarkets() {
-  const res = await fetch(`${BASE}/markets/?limit=100`);
+  const res = await fetch(`${BASE}/markets/?limit=500`);
   if (!res.ok) throw new Error(`Markets fetch failed: ${res.status}`);
   const data = await res.json();
   return (data.markets || []).map(m => ({
     id:     m.id,
     q:      m.question,
     cat:    m.category,
-    yes:    Math.round((m.current_odds || 0) * 100),
+    yes:    Math.max(1, Math.min(99, Math.round((m.current_odds || 0.5) * 100))),
     vol:    abbr(m.volume || 0),
     status: 'info',
     advice: '',

--- a/apps/dashboard/app/trade/page.jsx
+++ b/apps/dashboard/app/trade/page.jsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { getTrades, getWallet, getPositionValue, sellTrade, getAchievements } from '@/lib/api';
 import { useAchievement } from '@/components/AchievementContext';
 import { useTelegram } from '@/hooks/useTelegram';
@@ -142,6 +142,9 @@ export default function BetsPage() {
   const [sellTarget, setSellTarget] = useState(null); // trade to sell
   const { showAchievement }       = useAchievement();
   const { haptic }                = useTelegram();
+  // FIX: track which achievement IDs have already been shown this session
+  // so they don't pop up again on every refresh/load call.
+  const shownAchievements = useRef(new Set());
 
   const load = async (showRefresh = false) => {
     if (showRefresh) setRefreshing(true);
@@ -151,9 +154,21 @@ export default function BetsPage() {
       setWallet(w);
       if (t.length > 0) {
         const ach = await getAchievements();
-        if (t.length >= 1)  { const a = ach.find(x => x.id === 'first' && x.earned); if (a) showAchievement(a); }
-        if (t.length >= 10) { const a = ach.find(x => x.id === 'paper' && x.earned); if (a) showAchievement(a); }
-        if (t.length >= 50) { const a = ach.find(x => x.id === 'whale' && x.earned); if (a) showAchievement(a); }
+        const milestones = [
+          { count: 1,  id: 'first' },
+          { count: 10, id: 'paper' },
+          { count: 50, id: 'whale' },
+        ];
+        for (const { count, id } of milestones) {
+          if (t.length >= count && !shownAchievements.current.has(id)) {
+            const a = ach.find(x => x.id === id && x.earned);
+            if (a) {
+              shownAchievements.current.add(id);
+              showAchievement(a);
+              break; // show one at a time — don't stack popups
+            }
+          }
+        }
       }
     } finally {
       setLoading(false);


### PR DESCRIPTION
TradeModal.jsx:
- Clamp yes odds to 1-99 before computing price so price is never 0
- price=0 caused shares=amount/0=Infinity and payout=Infinity in the UI
- Root cause: signals whose market_id was outside the top-100 markets fetch returned current_odds=undefined, making yes=0

api.js (getSignals):
- Stop doing a second /markets/ fetch and relying on a 100-item lookup map
- The /signals/ endpoint already returns question, current_odds, volume, category enriched server-side — use those fields directly
- This fixes markets not appearing on the feed (signal market not in top-100)
- listMarkets limit raised 100→500 to cover full crypto market set
- getMarket + listMarkets: clamp yes to 1-99 consistently

trade/page.jsx:
- Add shownAchievements ref (Set) to track which achievement IDs have already been shown this browser session
- Previously showAchievement fired unconditionally on every load() call so 'First Trade' popup appeared on every refresh, not just first time
- Now each achievement ID is shown at most once per session
- Also shows only one popup at a time (break after first match)