### PR TITLE
feat: add sports markets + Crypto/Sports toggle on feed

### DIFF
--- a/apps/dashboard/app/globals.css
+++ b/apps/dashboard/app/globals.css
@@ -1384,3 +1384,44 @@ body::after {
   .ach-grid { grid-template-columns: repeat(4, 1fr); }
   .ach-popup { left: 50%; transform: translateX(-50%); max-width: 400px; }
 }
+/* ── Category toggle (Crypto / Sports) ─────────────────────────────────── */
+.cat-toggle-row {
+  display: flex;
+  gap: 8px;
+  padding: 0 16px 4px;
+  margin-bottom: 4px;
+}
+
+.cat-toggle-btn {
+  flex: 1;
+  padding: 10px 0;
+  border-radius: 12px;
+  border: 1.5px solid var(--border, rgba(255,255,255,0.08));
+  background: transparent;
+  color: var(--text-muted, rgba(255,255,255,0.45));
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.18s ease;
+  letter-spacing: 0.02em;
+}
+
+.cat-toggle-btn:hover {
+  border-color: var(--teal, #00d2c8);
+  color: var(--teal, #00d2c8);
+}
+
+.cat-toggle-btn.active {
+  background: rgba(0, 210, 200, 0.12);
+  border-color: var(--teal, #00d2c8);
+  color: var(--teal, #00d2c8);
+  box-shadow: 0 0 12px rgba(0, 210, 200, 0.15);
+}
+
+@media (min-width: 768px) {
+  .cat-toggle-row {
+    padding: 0 0 8px;
+    max-width: 320px;
+  }
+}

--- a/apps/dashboard/app/lib/api.js
+++ b/apps/dashboard/app/lib/api.js
@@ -25,38 +25,43 @@ const getStoredWallet = () => {
 
 // ─── SIGNALS ─────────────────────────────────────────────────────────────────
 
-export async function getSignals(filter = 'all') {
-  // Signals endpoint already embeds question, current_odds, volume, category —
-  // we only need the markets fetch as a secondary enrichment, not the source of truth.
-  const sigRes = await fetch(`${BASE}/signals/?top=20`);
+export async function getSignals(filter = 'all', category = 'crypto') {
+  // category: 'crypto' | 'sports' | 'all'
+  const categoryParam = category !== 'all' ? `&category=${category}` : '';
+  const sigRes = await fetch(`${BASE}/signals/?top=50${categoryParam}`);
   if (!sigRes.ok) throw new Error(`Failed to load signals`);
 
   const sigData = await sigRes.json();
   const rawSignals = Array.isArray(sigData) ? sigData : (sigData.signals || []);
 
-  const signals = rawSignals.map(s => {
-    const heatPct = Math.max(0, Math.min(100, Math.round((s.score || 0) * 100)));
-    const status  = heatPct >= 80 ? 'hot' : heatPct >= 50 ? 'warm' : 'cool';
+  // Sport categories
+  const SPORT_CATS = new Set(['NBA','NHL','Soccer','EPL','La Liga','Serie A','Bundesliga','Ligue 1','UCL','MLB','Tennis','Golf','Sports']);
+  const CRYPTO_CATS = new Set(['BTC','ETH','SOL','XRP','HYPE','Crypto']);
 
-    // FIX: use odds/question/category/volume directly from the signal object.
-    // The signals endpoint enriches these server-side — no second lookup needed.
-    // This prevents yes=0 (→ price=0 → Infinity shares) when a market isn't
-    // in the top-100 of the separate /markets/ response.
-    const rawOdds = s.current_odds ?? 0.5;
-    const yesInt  = Math.max(1, Math.min(99, Math.round(rawOdds * 100)));
+  const signals = rawSignals
+    .filter(s => {
+      if (category === 'crypto') return CRYPTO_CATS.has(s.category || 'Crypto');
+      if (category === 'sports') return SPORT_CATS.has(s.category || '');
+      return true;
+    })
+    .map(s => {
+      const heatPct = Math.max(0, Math.min(100, Math.round((s.score || 0) * 100)));
+      const status  = heatPct >= 80 ? 'hot' : heatPct >= 50 ? 'warm' : 'cool';
+      const rawOdds = s.current_odds ?? 0.5;
+      const yesInt  = Math.max(1, Math.min(99, Math.round(rawOdds * 100)));
 
-    return {
-      id:     s.market_id,
-      cat:    s.category || 'Crypto',
-      heat:   `${heatPct}° ${status.toUpperCase()}`,
-      status,
-      q:      s.question || s.reason || 'Unknown market',
-      yes:    yesInt,
-      vol:    abbr(s.volume || 0),
-      locked: (s.score || 0) >= 0.7,
-      advice: s.reason || '',
-    };
-  });
+      return {
+        id:     s.market_id,
+        cat:    s.category || 'Crypto',
+        heat:   `${heatPct}° ${status.toUpperCase()}`,
+        status,
+        q:      s.question || s.reason || 'Unknown market',
+        yes:    yesInt,
+        vol:    abbr(s.volume || 0),
+        locked: (s.score || 0) >= 0.7,
+        advice: s.reason || '',
+      };
+    });
 
   if (filter === 'all') return signals;
   return signals.filter(s => s.status === filter);

--- a/apps/dashboard/app/page.jsx
+++ b/apps/dashboard/app/page.jsx
@@ -11,12 +11,17 @@ import TradeModal from '@/components/TradeModal';
 import ChatSheet from '@/components/ChatSheet';
 import SkeletonCard from '@/components/SkeletonCard';
 
-const FILTERS = ['all', 'hot', 'warm', 'cool'];
+const FILTERS   = ['all', 'hot', 'warm', 'cool'];
+const CATEGORIES = [
+  { id: 'crypto', label: '📈 Crypto' },
+  { id: 'sports', label: '🏆 Sports' },
+];
 
 export default function FeedPage() {
   const { user } = useTelegram();
   const [signals, setSignals]         = useState([]);
   const [loading, setLoading]         = useState(true);
+  const [category, setCategory]       = useState('crypto');
   const [filter, setFilter]           = useState('all');
   const [tradeSignal, setTradeSignal] = useState(null);
   const [tradeSide, setTradeSide]     = useState('yes');
@@ -25,8 +30,8 @@ export default function FeedPage() {
 
   useEffect(() => {
     setLoading(true);
-    getSignals(filter).then(setSignals).finally(() => setLoading(false));
-  }, [filter]);
+    getSignals(filter, category).then(setSignals).finally(() => setLoading(false));
+  }, [filter, category]);
 
   const showToast = (msg) => { setToast(msg); setTimeout(() => setToast(null), 2200); };
   const handleTrade = (signal, side) => { setTradeSignal(signal); setTradeSide(side); };
@@ -65,6 +70,19 @@ export default function FeedPage() {
                 </button>
               ))}
             </div>
+          </div>
+
+          {/* Crypto / Sports category toggle */}
+          <div className="cat-toggle-row fu d1">
+            {CATEGORIES.map(c => (
+              <button
+                key={c.id}
+                className={`cat-toggle-btn ${category === c.id ? 'active' : ''}`}
+                onClick={() => { setCategory(c.id); setFilter('all'); }}
+              >
+                {c.label}
+              </button>
+            ))}
           </div>
 
           {/* Card grid */}

--- a/services/backend/api/markets.py
+++ b/services/backend/api/markets.py
@@ -1,18 +1,21 @@
 # markets.py
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
+from typing import Optional
 from sqlmodel import Session, select, text
 from datetime import datetime
 
 from services.backend.data.database import engine
 from services.backend.data.models import Market
-from services.backend.core.polymarket import fetch_short_term_crypto_markets
+from services.backend.core.polymarket import fetch_short_term_crypto_markets, fetch_sports_markets
 
 router = APIRouter(prefix="/markets", tags=["Markets"], redirect_slashes=False)
 
 
 def sync_markets(session: Session = None):
-    """Fetch crypto markets from Polymarket and upsert into DB."""
-    fresh_markets = fetch_short_term_crypto_markets(limit=300)
+    """Fetch crypto + sports markets from Polymarket and upsert into DB."""
+    crypto_markets = fetch_short_term_crypto_markets(limit=300)
+    sports_markets = fetch_sports_markets(limit=300)
+    fresh_markets  = crypto_markets + sports_markets
 
     if not fresh_markets:
         print("[sync] No markets returned from Polymarket.")
@@ -59,7 +62,7 @@ def sync_markets(session: Session = None):
                 print(f"[sync] Skipping {parsed.get('id')}: {e}")
 
         s.commit()
-        print(f"[sync] Upserted {saved} crypto markets.")
+        print(f"[sync] Upserted {saved} crypto + sports markets.")
 
     if session:
         _do_sync(session)
@@ -96,15 +99,29 @@ def debug_polymarket():
 
 
 @router.get("/")
-def get_markets(limit: int = 100, sort_by: str = "volume"):
+def get_markets(
+    limit: int = 500,
+    sort_by: str = "volume",
+    category: Optional[str] = Query(default=None, description="Filter by category group: 'crypto' or 'sports'"),
+):
+    # Categories that belong to each group
+    CRYPTO_CATS = {"BTC", "ETH", "SOL", "XRP", "HYPE", "Crypto"}
+    SPORTS_CATS = {"NBA", "NHL", "Soccer", "EPL", "La Liga", "Serie A",
+                   "Bundesliga", "Ligue 1", "UCL", "MLB", "Tennis", "Golf", "Sports"}
+
     with Session(engine) as session:
-        # Auto-sync if DB is empty
         total = len(session.exec(select(Market)).all())
         if total == 0:
             print("[markets] DB empty — syncing...")
             sync_markets(session)
 
         statement = select(Market).where(Market.is_active == True)
+
+        if category and category.lower() == "crypto":
+            statement = statement.where(Market.category.in_(list(CRYPTO_CATS)))
+        elif category and category.lower() == "sports":
+            statement = statement.where(Market.category.in_(list(SPORTS_CATS)))
+
         if sort_by == "volume":
             statement = statement.order_by(Market.volume.desc())
         statement = statement.limit(limit)

--- a/services/backend/core/polymarket.py
+++ b/services/backend/core/polymarket.py
@@ -27,6 +27,32 @@ CRYPTO_TAGS = {
     "xrp", "hyperliquid", "megaeth", "stablecoins", "etf",
 }
 
+# Sport sub-tag → display category label
+SPORT_LABELS = {
+    "nba":              "NBA",
+    "basketball":       "NBA",
+    "nba-finals":       "NBA",
+    "nba-champion":     "NBA",
+    "hockey":           "NHL",
+    "nhl":              "NHL",
+    "stanley-cup":      "NHL",
+    "soccer":           "Soccer",
+    "fifa-world-cup":   "Soccer",
+    "2026-fifa-world-cup": "Soccer",
+    "world-cup":        "Soccer",
+    "EPL":              "EPL",
+    "la-liga":          "La Liga",
+    "serie-a":          "Serie A",
+    "bundesliga":       "Bundesliga",
+    "ligue-1":          "Ligue 1",
+    "champions-league": "UCL",
+    "ucl":              "UCL",
+    "baseball":         "MLB",
+    "mlb":              "MLB",
+    "tennis":           "Tennis",
+    "golf":             "Golf",
+}
+
 # Slug prefixes for automated 5min/15min/hourly markets
 CRYPTO_SLUG_PREFIXES = [
     "btc-updown-5m-",
@@ -65,10 +91,25 @@ def _get_coin_label(text: str) -> str:
     return "Crypto"
 
 
+def _get_sport_label(event_tags: list) -> str:
+    """Derive a sport category label from an event's tag list."""
+    slugs = [t["slug"] for t in event_tags]
+    for slug in slugs:
+        if slug in SPORT_LABELS:
+            return SPORT_LABELS[slug]
+    return "Sports"
+
+
 def _is_crypto_event(event: Dict) -> bool:
     """Returns True if this event belongs to the crypto category."""
     tags = {t["slug"] for t in (event.get("tags") or [])}
     return bool(tags & CRYPTO_TAGS)
+
+
+def _is_sports_event(event: Dict) -> bool:
+    """Returns True if this event belongs to the sports category."""
+    tags = {t["slug"] for t in (event.get("tags") or [])}
+    return "sports" in tags
 
 
 def _fetch_events(params: dict) -> List[Dict]:
@@ -155,18 +196,54 @@ def fetch_short_term_crypto_markets(limit: int = 300) -> List[Dict]:
     return all_markets[:limit]
 
 
-def _extract_markets(event: Dict) -> List[Dict]:
+def fetch_sports_markets(limit: int = 300) -> List[Dict]:
+    """
+    Fetch all active sports markets from Polymarket.
+    Covers NBA, NHL, Soccer (FIFA/EPL/La Liga/UCL etc), and other sports.
+    Category field is set to the specific sport (NBA, NHL, Soccer, EPL etc.)
+    so the frontend can filter by sport within the Sports tab.
+    """
+    all_markets: List[Dict] = []
+    seen_ids: set = set()
+
+    def _add(market_dict: Dict):
+        mid = market_dict.get("id")
+        if mid and mid not in seen_ids:
+            seen_ids.add(mid)
+            all_markets.append(market_dict)
+
+    events = _fetch_events({
+        "active":   "true",
+        "closed":   "false",
+        "limit":    100,
+        "tag_slug": "sports",
+        "_sort":    "volume24hr",
+        "_order":   "desc",
+    })
+
+    for ev in events:
+        if not _is_sports_event(ev):
+            continue
+        sport_label = _get_sport_label(ev.get("tags") or [])
+        for m in _extract_markets(ev, category_override=sport_label):
+            _add(m)
+
+    print(f"[Polymarket] Total sports markets collected: {len(all_markets)}")
+    all_markets.sort(key=lambda m: m.get("volume", 0), reverse=True)
+    return all_markets[:limit]
+
+
+def _extract_markets(event: Dict, category_override: str = None) -> List[Dict]:
     """Extract and parse all child markets from a Polymarket event."""
     results = []
     event_title = event.get("title") or ""
-    # Pass event-level volume fields down so parse_market can use them
-    event_v24  = event.get("volume24hr") or 0
-    event_v1wk = event.get("volume1wk") or 0
+    event_v24   = event.get("volume24hr") or 0
+    event_v1wk  = event.get("volume1wk") or 0
 
     for m in (event.get("markets") or []):
         if not m.get("question"):
             m["question"] = event_title
-        parsed = parse_market(m, event_title, event_v24, event_v1wk)
+        parsed = parse_market(m, event_title, event_v24, event_v1wk, category_override)
         if parsed:
             results.append(parsed)
     return results
@@ -177,6 +254,7 @@ def parse_market(
     event_title: str = "",
     event_v24: float = 0,
     event_v1wk: float = 0,
+    category_override: str = None,
 ) -> Optional[Dict]:
     """
     Converts a raw Polymarket market item into our Market schema dict.
@@ -225,7 +303,7 @@ def parse_market(
     return {
         "id":            market_id,
         "question":      question,
-        "category":      _get_coin_label(question),
+        "category":      category_override or _get_coin_label(question),
         "current_odds":  current_odds,
         # FIX for issue #7: previous_odds is intentionally None for new markets.
         # On a brand-new insert, markets.py will store 0.5 as default.


### PR DESCRIPTION
Backend:
- polymarket.py: add fetch_sports_markets() — fetches 300 sports markets from Polymarket sports tag (NBA, NHL, Soccer/FIFA, EPL, La Liga, UCL etc.) Sport sub-tags map to specific category labels (NBA, NHL, Soccer, EPL...) so the frontend can filter by sport group. Category override param added to parse_market() and _extract_markets() so sports get correct labels instead of falling through to _get_coin_label().
- markets.py: sync_markets() now calls both fetch_short_term_crypto_markets() and fetch_sports_markets() — both go into the same Market table. GET /markets/ now accepts ?category=crypto or ?category=sports query param to return only that group. Default (no param) returns all 600 markets. Limit raised from 100 to 500 default.

Frontend:
- api.js: getSignals() now accepts a category param ('crypto'|'sports'|'all') and client-side filters by CRYPTO_CATS / SPORTS_CATS sets. Signals top raised to 50 so there are enough for both categories after filtering.
- page.jsx: add CATEGORIES constant and cat-toggle-row above the feed cards. Switching category resets heat filter to 'all'. Both filter and category are independent — Hot/Warm/Cool still works within whichever tab is active.
- globals.css: .cat-toggle-btn and .cat-toggle-btn.active styles added.