### PR TITLE
feat: replace OpenClaw chat button with market ID copy button

### DIFF
--- a/apps/dashboard/app/components/FeedCard.jsx
+++ b/apps/dashboard/app/components/FeedCard.jsx
@@ -1,9 +1,11 @@
 'use client';
+import { useState } from 'react';
 import { useTelegram } from '@/hooks/useTelegram';
 
-export default function FeedCard({ data, index, onTrade, onChat }) {
+export default function FeedCard({ data, index, onTrade }) {
   const { haptic } = useTelegram();
   const delay = `d${(index % 6) + 1}`;
+  const [copied, setCopied] = useState(false);
 
   const handleTrade = (side, e) => {
     e.stopPropagation();
@@ -11,10 +13,26 @@ export default function FeedCard({ data, index, onTrade, onChat }) {
     onTrade?.(data, side);
   };
 
-  const handleChat = (e) => {
+  const handleCopyId = (e) => {
     e.stopPropagation();
     haptic.light();
-    onChat?.(data);
+    navigator.clipboard.writeText(data.id).then(() => {
+      setCopied(true);
+      haptic.success?.();
+      setTimeout(() => setCopied(false), 2000);
+    }).catch(() => {
+      // Fallback for environments where clipboard API isn't available
+      const el = document.createElement('textarea');
+      el.value = data.id;
+      el.style.position = 'fixed';
+      el.style.opacity = '0';
+      document.body.appendChild(el);
+      el.select();
+      document.execCommand('copy');
+      document.body.removeChild(el);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
   };
 
   return (
@@ -49,25 +67,15 @@ export default function FeedCard({ data, index, onTrade, onChat }) {
           <button className="bet-btn" onClick={(e) => handleTrade('no', e)}>▼ Bet NO</button>
         </div>
 
-        {/* AI Advice */}
-        <div className="advice-wrap">
-          <div className="advice-glass">
-            <div className="advice-text">{data.advice}</div>
-          </div>
-          {data.locked ? (
-            <div className="advice-lock">
-              <button className="lock-btn" onClick={handleChat}>
-                Ask OpenClaw · 0.10 USDC
-              </button>
-            </div>
-          ) : (
-            <div className="advice-lock" style={{ borderTop: 'none', padding: '0 12px 10px' }}>
-              <button className="chip-btn" style={{ width: '100%' }} onClick={handleChat}>
-                Chat OpenClaw →
-              </button>
-            </div>
-          )}
-        </div>
+        {/* Market ID copy button */}
+        <button
+          className={`market-id-btn ${copied ? 'copied' : ''}`}
+          onClick={handleCopyId}
+        >
+          <span className="market-id-label">ID</span>
+          <span className="market-id-value">{data.id}</span>
+          <span className="market-id-action">{copied ? '✓ Copied' : '⎘ Copy'}</span>
+        </button>
       </div>
     </div>
   );

--- a/apps/dashboard/app/globals.css
+++ b/apps/dashboard/app/globals.css
@@ -1444,3 +1444,71 @@ body::after {
     max-width: 320px;
   }
 }
+
+/* ── Market ID copy button ──────────────────────────────────────────────── */
+.market-id-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px;
+  border-radius: var(--rsm);
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.03);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-align: left;
+  overflow: hidden;
+}
+
+.market-id-btn:hover {
+  border-color: var(--teal-border);
+  background: var(--teal-glow);
+}
+
+.market-id-btn.copied {
+  border-color: var(--green);
+  background: rgba(52, 211, 153, 0.08);
+}
+
+.market-id-label {
+  font-family: 'DM Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  padding: 2px 6px;
+  border: 1px solid var(--glass-border);
+  border-radius: 4px;
+  background: var(--glass-bg);
+}
+
+.market-id-value {
+  font-family: 'DM Mono', monospace;
+  font-size: 11px;
+  color: var(--text-secondary);
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.market-id-action {
+  font-family: 'DM Mono', monospace;
+  font-size: 10px;
+  color: var(--teal);
+  flex-shrink: 0;
+  opacity: 0.7;
+  transition: opacity 0.2s;
+}
+
+.market-id-btn.copied .market-id-action {
+  color: var(--green);
+  opacity: 1;
+}
+
+.market-id-btn.copied .market-id-value {
+  color: var(--green);
+}

--- a/apps/dashboard/app/page.jsx
+++ b/apps/dashboard/app/page.jsx
@@ -8,7 +8,6 @@ import AuthGate from '@/components/AuthGate';
 import FeedCard from '@/components/FeedCard';
 import Navbar from '@/components/Navbar';
 import TradeModal from '@/components/TradeModal';
-import ChatSheet from '@/components/ChatSheet';
 import SkeletonCard from '@/components/SkeletonCard';
 
 const FILTERS   = ['all', 'hot', 'warm', 'cool'];
@@ -25,7 +24,6 @@ export default function FeedPage() {
   const [filter, setFilter]           = useState('all');
   const [tradeSignal, setTradeSignal] = useState(null);
   const [tradeSide, setTradeSide]     = useState('yes');
-  const [chatSignal, setChatSignal]   = useState(null);
   const [toast, setToast]             = useState(null);
 
   useEffect(() => {
@@ -95,7 +93,6 @@ export default function FeedPage() {
                     data={sig}
                     index={i}
                     onTrade={handleTrade}
-                    onChat={setChatSignal}
                   />
                 ))
             }
@@ -120,9 +117,6 @@ export default function FeedPage() {
             onClose={() => setTradeSignal(null)}
             onSuccess={() => showToast('Paper trade placed ✓')}
           />
-        )}
-        {chatSignal && (
-          <ChatSheet signal={chatSignal} onClose={() => setChatSignal(null)} />
         )}
 
         {toast && <div className="toast">{toast}</div>}


### PR DESCRIPTION
FeedCard.jsx:
- Removed entire advice-wrap section (AI advice text, Ask OpenClaw button, Chat OpenClaw button, locked/unlocked states, x402 payment flow)
- Removed onChat prop — no longer needed
- Added market-id-btn: shows ID label + truncated market ID + Copy action
- On click: copies data.id to clipboard via navigator.clipboard with execCommand fallback for environments where clipboard API is unavailable
- copied state drives a 2-second visual confirmation (green border, tick)
- haptic.success fires on successful copy

page.jsx:
- Removed ChatSheet import
- Removed chatSignal state
- Removed onChat={setChatSignal} from FeedCard props
- Removed ChatSheet modal render

globals.css:
- Added .market-id-btn, .market-id-label, .market-id-value, .market-id-action
- Default: glass border, muted text, teal Copy label
- Hover: teal border glow
- .copied state: green border + green text + tick confirmation