### PR TITLE
feat: filter near-resolved markets with odds outside 5%-95% range

### DIFF
--- a/services/backend/api/markets.py
+++ b/services/backend/api/markets.py
@@ -10,6 +10,10 @@ from services.backend.core.polymarket import fetch_short_term_crypto_markets, fe
 
 router = APIRouter(prefix="/markets", tags=["Markets"], redirect_slashes=False)
 
+# Mirrors the threshold in polymarket.py and signals_engine.py
+MIN_TRADEABLE_ODDS = 0.05
+MAX_TRADEABLE_ODDS = 0.95
+
 
 def sync_markets(session: Session = None):
     """Fetch crypto + sports markets from Polymarket and upsert into DB."""
@@ -115,7 +119,11 @@ def get_markets(
             print("[markets] DB empty — syncing...")
             sync_markets(session)
 
-        statement = select(Market).where(Market.is_active == True)
+        statement = select(Market).where(
+            Market.is_active == True,
+            Market.current_odds >= MIN_TRADEABLE_ODDS,
+            Market.current_odds <= MAX_TRADEABLE_ODDS,
+        )
 
         if category and category.lower() == "crypto":
             statement = statement.where(Market.category.in_(list(CRYPTO_CATS)))

--- a/services/backend/core/polymarket.py
+++ b/services/backend/core/polymarket.py
@@ -21,6 +21,10 @@ from typing import List, Dict, Optional
 
 GAMMA_API = os.getenv("POLYMARKET_API_URL", "https://gamma-api.polymarket.com")
 
+# Markets with odds outside this range are effectively resolved — drop at source
+MIN_TRADEABLE_ODDS = 0.05   # 5%
+MAX_TRADEABLE_ODDS = 0.95   # 95%
+
 # Tags that identify an event as crypto-related
 CRYPTO_TAGS = {
     "crypto", "crypto-prices", "bitcoin", "ethereum", "solana",
@@ -281,6 +285,10 @@ def parse_market(
             current_odds = 0.5
     except Exception:
         current_odds = 0.5
+
+    # Drop markets that are effectively resolved — no trading value
+    if current_odds < MIN_TRADEABLE_ODDS or current_odds > MAX_TRADEABLE_ODDS:
+        return None
 
     # Parse expiry
     try:

--- a/services/backend/core/signals_engine.py
+++ b/services/backend/core/signals_engine.py
@@ -15,6 +15,10 @@ MIN_LIQUIDITY = 1000.0      # Markets below this are too thin to trade
 MOMENTUM_WEIGHT = 0.5       # How much price movement matters in final score
 VOLUME_WEIGHT = 0.5         # How much volume spike matters in final score
 
+# Markets with odds outside this range are effectively resolved — no trading value
+MIN_TRADEABLE_ODDS = 0.05   # 5%
+MAX_TRADEABLE_ODDS = 0.95   # 95%
+
 
 # ─────────────────────────────────────────────
 # STEP 1 — LIQUIDITY FILTER
@@ -22,13 +26,23 @@ VOLUME_WEIGHT = 0.5         # How much volume spike matters in final score
 # If a market fails this, it never gets ranked.
 # ─────────────────────────────────────────────
 
-def passes_liquidity_filter(market: Dict) -> bool:
+def passes_market_filter(market: Dict) -> bool:
     """
-    Returns True if the market has enough liquidity to be worth ranking.
-    Uses the 'volume' field as a proxy for liquidity.
+    Returns True if the market passes both liquidity and odds filters.
+
+    A market is excluded if:
+      - Volume is below MIN_LIQUIDITY (too thin to trade)
+      - current_odds is outside 5%-95% (effectively already resolved)
     """
     volume = market.get("volume", 0)
-    return volume >= MIN_LIQUIDITY
+    if volume < MIN_LIQUIDITY:
+        return False
+
+    odds = market.get("current_odds", 0.5)
+    if odds < MIN_TRADEABLE_ODDS or odds > MAX_TRADEABLE_ODDS:
+        return False
+
+    return True
 
 
 # ─────────────────────────────────────────────
@@ -158,8 +172,8 @@ def rank_markets(markets: List[Dict], top: int = 20) -> List[Dict]:
       - current_odds
       - volume
     """
-    # Step 1: filter
-    liquid_markets = [m for m in markets if passes_liquidity_filter(m)]
+    # Step 1: filter — liquidity + odds range
+    liquid_markets = [m for m in markets if passes_market_filter(m)]
 
     # Step 2 & 3: score and sort
     scored = sorted(liquid_markets, key=composite_score, reverse=True)


### PR DESCRIPTION
- polymarket.py: drop markets at parse time if odds < 0.05 or > 0.95
- signals_engine.py: rename passes_liquidity_filter to passes_market_filter, add odds check
- markets.py: apply odds filter to /markets/ SQL query

Threshold constants defined per-file for easy tuning.