### PR TITLE
feat: add background market auto-sync every 15 minutes

### DIFF
--- a/services/backend/main.py
+++ b/services/backend/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from contextlib import asynccontextmanager
 from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import Session
+import asyncio
 
 from services.backend.api.signals import router as signals_router
 from services.backend.api.markets import router as markets_router, sync_markets
@@ -10,6 +11,26 @@ from services.backend.api.wallet import router as wallet_router
 from services.backend.api.advice import router as advice_router
 from services.backend.api.leaderboard import router as leaderboard_router
 from services.backend.data.database import init_db, engine
+
+# How often to auto-sync markets from Polymarket (in seconds)
+SYNC_INTERVAL_SECONDS = 15 * 60  # 15 minutes
+
+
+async def _market_sync_loop():
+    """
+    Background task that re-syncs markets from Polymarket every 15 minutes.
+    Runs for the lifetime of the server — started in lifespan, cancelled on shutdown.
+    Errors are caught and logged so a single failed sync never kills the loop.
+    """
+    while True:
+        await asyncio.sleep(SYNC_INTERVAL_SECONDS)
+        print(f"[scheduler] Auto-syncing markets from Polymarket...")
+        try:
+            with Session(engine) as session:
+                sync_markets(session)
+            print("[scheduler] Auto-sync complete.")
+        except Exception as e:
+            print(f"[scheduler] Auto-sync failed (will retry in {SYNC_INTERVAL_SECONDS // 60} min): {e}")
 
 
 @asynccontextmanager
@@ -23,10 +44,20 @@ async def lifespan(app: FastAPI):
             sync_markets(session)
         print("Market sync complete.")
     except Exception as e:
-        # Don't crash the server if Polymarket is unreachable at boot
         print(f"Market sync failed (will retry on first /markets request): {e}")
 
+    # Start background sync loop
+    sync_task = asyncio.create_task(_market_sync_loop())
+    print(f"[scheduler] Market auto-sync started — every {SYNC_INTERVAL_SECONDS // 60} minutes.")
+
     yield
+
+    # Clean shutdown — cancel the background task
+    sync_task.cancel()
+    try:
+        await sync_task
+    except asyncio.CancelledError:
+        pass
     print("Shutting down...")
 
 


### PR DESCRIPTION
- Added _market_sync_loop() async task that wakes every 15 min and calls sync_markets()
- Task is started in lifespan on server boot and cleanly cancelled on shutdown
- Errors in individual syncs are caught and logged — loop never dies on failure
- SYNC_INTERVAL_SECONDS constant at top of file for easy tuning
- No new dependencies — uses asyncio which is already part of FastAPI